### PR TITLE
feat: migrate to node 18

### DIFF
--- a/npm.json
+++ b/npm.json
@@ -6,7 +6,7 @@
     "isolatedModules": false,
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "node16",
-    "target": "ES2021",
+    "target": "ES2022",
     "moduleResolution": "node16",
     "sourceMap": true,
     "declaration": true,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@beesley/tsconfig",
   "version": "2.0.0",
   "description": "Useful tsconfig files for stuff",
+  "engines": {
+    "node": ">=18.12"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Updates the target to support node 18 rather than node 16.

BREAKING CHANGE: Drops support for nodejs versions below 18.12